### PR TITLE
Added use-group-intersection flag and fixed XML reporting bug

### DIFF
--- a/proboscis/case.py
+++ b/proboscis/case.py
@@ -243,6 +243,10 @@ class TestResultListener():
         self.onError(test)
         self.chain_to_cls.addFailure(self, test, err)
 
+    def addSkip(self, test, err):
+        self.onError(test)
+        self.chain_to_cls.addSkip(self, test, err)
+
     def onError(self, test):
         """Notify a test entry and its dependents of failure."""
         if dependencies.use_nose:

--- a/proboscis/core.py
+++ b/proboscis/core.py
@@ -169,7 +169,6 @@ class TestEntry(object):
                     raise RuntimeError("TestEntry depends on a group it " \
                                        "itself belongs to: " + str(self))
 
-
     def contains(self, group_names, classes):
         """True if this belongs to any of the given groups or classes."""
         for group_name in group_names:
@@ -201,6 +200,13 @@ class TestEntry(object):
         self.__method = method
         self.__method_cls = cls
         self.homes = set([self.home, cls])
+
+    def get_method_name(self):
+        """ Returns the stringified version of __method_cls, prettified up.
+        (Added by David Cully, Adelphic Inc, January 2015) """
+        # example raw: <class '__main__.MyFancyTestClassName'>
+        raw = str(self.__method_cls)
+        return raw[raw.find(".") + 1:raw.find(">") - 1]
 
     def mark_as_used_by_factory(self):
         """If a Factory returns an instance of a class, the class will not


### PR DESCRIPTION
I've made two code changes here that you guys might be interested in - one bug fix, one feature.

I added an optional command line flag (--use-group-intersection) to allow for filtering test cases by the intersection of all inputted command line groups.

I tweaked the integration code with nose2's XUnit plugin (--with-xunit) so that the generated XML output correctly displays class names for test methods, instead of just displaying the method name twice. This is really nice if you're running the test harness out of something like Jenkins.

Cheers!
